### PR TITLE
enhancement-support_for_no_ties

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,10 +100,13 @@ def main():
     # standings do not automatically have ties - need to account for this for future seasons
     # for now, manually added column for 2023
     stnd = ex.build_stnd(afc, nfc).set_index('Tm')
+    
 
     # populate Postgres
     dfs = [stnd, pass_o, pass_d, rush_o, rush_d, air_yards, accuracy, pressure, rush_adv, rec_adv]
-
+    if 'T' not in stnd:
+        stnd['T'] = 0
+  
     # setup connections to postgres DB
     try:
         conn_string = 'postgresql://moose:moose@127.0.0.1/nfletl_dev'

--- a/nfl_etl/models/season_historical_by_year.sql
+++ b/nfl_etl/models/season_historical_by_year.sql
@@ -252,5 +252,4 @@ ON
 	stnd."Tm" = rush_d."Tm"
 ORDER BY 
     year DESC, 
-	win DESC,
-	tie DESC
+	team ASC


### PR DESCRIPTION
nfl_standings_{year} table now adds a column for Ties and fills them in with 0's if there were no ties that year. Required for downstream views